### PR TITLE
Remove events variable assignment

### DIFF
--- a/lib/goby/world_command.rb
+++ b/lib/goby/world_command.rb
@@ -60,7 +60,6 @@ module Goby
     # @param [Player] player the player who needs the tile description.
     def describe_tile(player)
       tile = player.location.map.tiles[player.location.coords.first][player.location.coords.second]
-      events = tile.events
 
       player.print_minimap
       print "#{tile.description}\n\n"


### PR DESCRIPTION
This commit removes a superfluous variable assignment in
Goby::WorldComman#describe_tile. A variable "events" was being assigned,
but not used in the #describe_tile function. This commit removes that
variable assignment as a matter of keeping the code clean.