### PR TITLE
Add private method to enhance readability

### DIFF
--- a/lib/goby/driver.rb
+++ b/lib/goby/driver.rb
@@ -26,7 +26,7 @@ module Goby
     # Runs a single command from the player on the world map.
     #
     # @param [Player] player the player of the game.
-    # @return [Bool] true iff the player does not want to quit.
+    # @return [Bool] true if the player does not want to quit.
     def run_turn(player)
 
       # Play music and re-display the minimap (when appropriate).
@@ -41,7 +41,14 @@ module Goby
       input = player_input prompt: '> '
       interpret_command(input, player)
 
-      return !input.eql?("quit")
+      return continue_game?(input)
     end
 
+    # Checks to see if game should continue.
+    #
+    # @param [Input] text the input text of the player.
+    # @return [Bool] true if the player does not want to quit.
+    def continue_game?(input)
+      !input.eql?("quit")
+    end
 end


### PR DESCRIPTION
module Goby contains a private method `run_turn` that had a check at the
end of the function definition. While it is acceptable practice to use a
not operator ("!") before a function call, it can decrease the
readability of logic and increases cognitive overhead to understand the
meaning of the code. Creating a new private method `continue_game?`
makes explicit the purpose of that logic check at the end of the
`run_turn` method within the context of the game.

This PR also fixes a minor typo in the documentation of the `run_turn` function.